### PR TITLE
feat: configure manual-only GitHub Actions and add pnpm support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,23 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
   workflow_dispatch:
+    inputs:
+      run_tests:
+        description: 'Run tests and linting'
+        required: true
+        default: true
+        type: boolean
+      deploy_preview:
+        description: 'Deploy preview (requires PR context)'
+        required: false
+        default: false
+        type: boolean
+      deploy_production:
+        description: 'Deploy to production (main branch only)'
+        required: false
+        default: false
+        type: boolean
 
 env:
   NODE_VERSION: '18'
@@ -15,6 +27,7 @@ jobs:
   test:
     name: Test & Lint
     runs-on: ubuntu-latest
+    if: github.event.inputs.run_tests == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,7 +61,7 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'pull_request'
+    if: github.event.inputs.deploy_preview == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -64,7 +77,7 @@ jobs:
     name: Deploy Production
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main'
+    if: github.event.inputs.deploy_production == 'true' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This PR adds improvements to the CI/CD pipeline configuration and developer workflow.

## Changes Made

### 🔒 **GitHub Actions Configuration**
- **Manual Trigger Only**: Removed automatic triggers (push, pull_request) 
- **Workflow Dispatch**: Added manual workflow controls with configurable inputs:
  - `run_tests`: Enable/disable test and lint jobs (default: true)
  - `deploy_preview`: Enable/disable preview deployment (default: false) 
  - `deploy_production`: Enable/disable production deployment (default: false)
- **Granular Control**: Each job now respects workflow input parameters

### 📦 **Package Manager Support**
- **pnpm Lock File**: Added `pnpm-lock.yaml` to resolve CI/CD pipeline failures
- **Verified Build**: Confirmed all builds pass with pnpm package manager

### 🛡️ **Branch Protection**
- **Develop Branch**: Protected from deletion via GitHub API
- **Safe Development**: Prevents accidental branch deletion during PR operations

## Benefits
- **Cost Efficient**: No automatic CI runs consuming GitHub Actions minutes
- **Developer Control**: Manual workflow execution when needed
- **Pipeline Stability**: Proper pnpm lockfile ensures consistent dependency resolution
- **Branch Safety**: Protected develop branch prevents workflow disruption

## How to Use
Navigate to Actions tab → Select workflow → Click 'Run workflow' → Configure options → Run

Ready for merge into main branch.